### PR TITLE
Change name from Janus to Mensendi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Janus
+# Mensendi
 
-![master build status](https://travis-ci.org/jgsmith/janus.svg?branch=master)
+![master build status](https://travis-ci.org/jgsmith/mensendi.svg?branch=master)
 
-Janus is a project with which I'm learning Elixir. It's also a combination HL7 integration
+Mensendi is a project with which I'm learning Elixir. It's also a combination HL7 integration
 engine and protected health information vault. For now, it's focused on capturing the HL7v2.5
 message structures and the ability to parse messages into useful data structures.

--- a/mix.exs
+++ b/mix.exs
@@ -1,8 +1,8 @@
-defmodule Janus.Mixfile do
+defmodule Mensendi.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :janus,
+    [app: :mensendi,
      version: "0.1.0",
      elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,


### PR DESCRIPTION
Janus is a name that already has health-related connotations. Mensendi is a made-up word, so it's a decent project name.
